### PR TITLE
add links missing of menu on home page

### DIFF
--- a/web/views/home.html
+++ b/web/views/home.html
@@ -10,7 +10,12 @@
                 <div class="items">
                     <div class="item-info">
                         <p>
-                            <a href="/mempool" class="header">Mempool -</a> Historical data on decred full node mempool size.
+                            <a href="/mempool" class="header">Nodes -</a> Historical data about detected full nodes.
+                        </p>
+                    </div>
+                    <div class="item-info">
+                        <p>
+                            <a href="/mempool" class="header">Mempool -</a> Historical data on full node mempool size.
                         </p>
                     </div>
                     <div class="item-info">
@@ -36,6 +41,11 @@
                     <div class="item-info">
                         <p>
                             <a href="/community" class="header">Community -</a> Historical data points for twitter, reddit, github, etc.
+                        </p>
+                    </div>
+                    <div class="item-info">
+                        <p>
+                            <a href="/mempool" class="header">Stats -</a> DB stats about dcrextdata.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
This pr adds the links that are missing of the menu on the home page and its description

- Nodes - Historical data about detected full nodes.
- Stats - DB stats about dcrextdata.
Also eliminates the word "decred" in the Mempool paragraph.


![2020-06-02_02-10-21](https://user-images.githubusercontent.com/60282692/83491221-0dee3580-a477-11ea-8566-08bc83f97ae6.png)

