### PR TITLE
Show switch for time and block on x axis

### DIFF
--- a/cache/badger.go
+++ b/cache/badger.go
@@ -1036,59 +1036,59 @@ func (charts *ChartData) lengthenMempool() error {
 }
 
 func (charts *ChartData) updateMempoolHeights(txn *badger.Txn) error {
-    var mempoolDates, propagationDates, mempoolHeights, propagationHeights ChartUints
-    if err := charts.ReadValTx(fmt.Sprintf("%s-%s", Mempool, TimeAxis), &mempoolDates, txn); err != nil {
-        if err == badger.ErrKeyNotFound {
-            log.Warn("Mempool height not updated, mempool dates has no value")
-            return nil
-        }
-        return err
-    }
+	var mempoolDates, propagationDates, mempoolHeights, propagationHeights ChartUints
+	if err := charts.ReadValTx(fmt.Sprintf("%s-%s", Mempool, TimeAxis), &mempoolDates, txn); err != nil {
+		if err == badger.ErrKeyNotFound {
+			log.Warn("Mempool height not updated, mempool dates has no value")
+			return nil
+		}
+		return err
+	}
 
-    if mempoolDates.Length() == 0 {
-        log.Warn("Mempool height not updated, mempool dates has no value")
-        return nil
-    }
+	if mempoolDates.Length() == 0 {
+		log.Warn("Mempool height not updated, mempool dates has no value")
+		return nil
+	}
 
-    if err := charts.ReadValTx(fmt.Sprintf("%s-%s", Propagation, TimeAxis), &propagationDates, txn); err != nil {
-        if err == badger.ErrKeyNotFound {
-            log.Warn("Mempool height not updated, propagation dates has no value")
-            return nil
-        }
-        return err
-    }
+	if err := charts.ReadValTx(fmt.Sprintf("%s-%s", Propagation, TimeAxis), &propagationDates, txn); err != nil {
+		if err == badger.ErrKeyNotFound {
+			log.Warn("Mempool height not updated, propagation dates has no value")
+			return nil
+		}
+		return err
+	}
 
-    if propagationDates.Length() == 0 {
-        log.Warn("Mempool height not updated, propagation dates has no value")
-        return nil
-    }
+	if propagationDates.Length() == 0 {
+		log.Warn("Mempool height not updated, propagation dates has no value")
+		return nil
+	}
 
-    if err := charts.ReadValTx(fmt.Sprintf("%s-%s", Propagation, HeightAxis), &propagationHeights, txn); err != nil {
-        if err == badger.ErrKeyNotFound {
-            log.Warn("Mempool height not updated, propagation heights has no value")
-            return nil
-        }
-        return err
-    }
+	if err := charts.ReadValTx(fmt.Sprintf("%s-%s", Propagation, HeightAxis), &propagationHeights, txn); err != nil {
+		if err == badger.ErrKeyNotFound {
+			log.Warn("Mempool height not updated, propagation heights has no value")
+			return nil
+		}
+		return err
+	}
 
-    if propagationHeights.Length() == 0 {
-        log.Warn("Mempool height not updated, propagation heights has no value")
-        return nil
-    }
+	if propagationHeights.Length() == 0 {
+		log.Warn("Mempool height not updated, propagation heights has no value")
+		return nil
+	}
 
-    pIndex := 0
-    for _, date := range mempoolDates {
-        if pIndex+1 < propagationDates.Length() && date >= propagationDates[pIndex+1] {
-            pIndex += 1
-        }
-        mempoolHeights = append(mempoolHeights, propagationHeights[pIndex])
-    }
+	pIndex := 0
+	for _, date := range mempoolDates {
+		if pIndex+1 < propagationDates.Length() && date >= propagationDates[pIndex+1] {
+			pIndex += 1
+		}
+		mempoolHeights = append(mempoolHeights, propagationHeights[pIndex])
+	}
 
-    if err := charts.SaveValTx(fmt.Sprintf("%s-%s", Mempool, HeightAxis), mempoolHeights, txn); err != nil {
-        return err
-    }
+	if err := charts.SaveValTx(fmt.Sprintf("%s-%s", Mempool, HeightAxis), mempoolHeights, txn); err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 func (charts *ChartData) lengthenPropagation() error {

--- a/cache/badger.go
+++ b/cache/badger.go
@@ -1006,7 +1006,9 @@ func (charts *ChartData) lengthenMempool() error {
 		return err
 	}
 
-	dayIntervals, hourIntervals, err := charts.lengthenTime(fmt.Sprintf("%s-%s", Mempool, TimeAxis), txn)
+	dayIntervals, hourIntervals, err := charts.lengthenTimeAndHeight(
+		fmt.Sprintf("%s-%s", Mempool, TimeAxis),
+		fmt.Sprintf("%s-%s", Mempool, HeightAxis), txn)
 	if err != nil {
 		return err
 	}
@@ -1094,7 +1096,7 @@ func (charts *ChartData) lengthenPropagation() error {
 	defer txn.Discard()
 
 	key := fmt.Sprintf("%s-%s", Propagation, TimeAxis)
-	dayIntervals, hourIntervals, err := charts.lengthenTime(key, txn)
+	dayIntervals, hourIntervals, err := charts.lengthenTimeAndHeight(key, fmt.Sprintf("%s-%s", Propagation, HeightAxis), txn)
 	if err != nil {
 		return err
 	}
@@ -1335,6 +1337,111 @@ func (charts *ChartData) lengthenTime(key string, txn *badger.Txn) (dayIntervals
 	}
 
 	if err = charts.SaveValTx(fmt.Sprintf("%s-%s", key, hourBin), hours, txn); err != nil {
+		return
+	}
+
+	return
+}
+
+func (charts *ChartData) lengthenTimeAndHeight(timeKey, heightKey string, txn *badger.Txn) (dayIntervals [][2]int, hourIntervals [][2]int, err error) {
+	var dates, heights ChartUints
+	if err = charts.ReadValTx(timeKey, &dates, txn); err != nil {
+		if err == badger.ErrKeyNotFound {
+			err = nil
+			return
+		}
+		return
+	}
+
+	if err = charts.ReadValTx(heightKey, &heights, txn); err != nil {
+		if err == badger.ErrKeyNotFound {
+			err = nil
+			return
+		}
+		return
+	}
+
+	if dates.Length() == 0 {
+		return
+	}
+
+	// day bin
+	var days, dayHeights ChartUints
+	// Get the current first and last midnight stamps.
+	var start = midnight(dates[0])
+	end := midnight(dates[len(dates)-1])
+
+	// the index that begins new data.
+	offset := 0
+	// If there is day or more worth of new data, append to the Days zoomSet by
+	// finding the first and last+1 blocks of each new day, and taking averages
+	// or sums of the blocks in the interval.  0.06096031
+	if end > start+aDay {
+		next := start + aDay
+		startIdx := 0
+		for i, t := range dates[offset:] {
+			if t >= next {
+				// Once passed the next midnight, prepare a day window by
+				// storing the range of indices. 0, 1, 2, 3, 4, 5
+				dayIntervals = append(dayIntervals, [2]int{startIdx + offset, i + offset})
+				// check for records b/4 appending.
+				days = append(days, start)
+				dayHeights = append(dayHeights, heights[i])
+				next = midnight(t)
+				start = next
+				next += aDay
+				startIdx = i
+				if t > end {
+					break
+				}
+			}
+		}
+	}
+
+	if err = charts.SaveValTx(fmt.Sprintf("%s-%s", timeKey, dayBin), days, txn); err != nil {
+		return
+	}
+
+	if err = charts.SaveValTx(fmt.Sprintf("%s-%s", heightKey, dayBin), dayHeights, txn); err != nil {
+		return
+	}
+
+	// hour bin
+	var hours, hourHeights ChartUints
+	// Get the current first and last hour stamps.
+	start = hourStamp(dates[0])
+	end = hourStamp(dates[len(dates)-1])
+
+	// the index that begins new data.
+	offset = 0
+	// If there is day or more worth of new data, append to the Days zoomSet by
+	// finding the first and last+1 blocks of each new day, and taking averages
+	// or sums of the blocks in the interval.
+	if end > start+anHour {
+		next := start + anHour
+		startIdx := 0
+		for i, t := range dates[offset:] {
+			if t >= next {
+				// Once passed the next hour, prepare a day window by storing
+				// the range of indices.
+				hourIntervals = append(hourIntervals, [2]int{startIdx + offset, i + offset})
+				hours = append(hours, start)
+				hourHeights = append(hourHeights, heights[i])
+				next = hourStamp(t)
+				start = next
+				next += anHour
+				startIdx = i
+				if t > end {
+					break
+				}
+			}
+		}
+	}
+
+	if err = charts.SaveValTx(fmt.Sprintf("%s-%s", timeKey, hourBin), hours, txn); err != nil {
+		return
+	}
+	if err = charts.SaveValTx(fmt.Sprintf("%s-%s", heightKey, hourBin), hourHeights, txn); err != nil {
 		return
 	}
 

--- a/cache/chart.go
+++ b/cache/chart.go
@@ -1198,22 +1198,25 @@ func (charts *ChartData) trim(sets ...Lengther) []Lengther {
 	return sets
 }
 
-func mempool(ctx context.Context, charts *ChartData, dataType, _ axisType, bin binLevel, _ ...string) ([]byte, error) {
+func mempool(ctx context.Context, charts *ChartData, dataType, axis axisType, bin binLevel, _ ...string) ([]byte, error) {
 	switch dataType {
 	case MempoolSize:
-		return mempoolSize(charts, bin)
+		return mempoolSize(charts, axis, bin)
 	case MempoolTxCount:
-		return mempoolTxCount(charts, bin)
+		return mempoolTxCount(charts, axis, bin)
 	case MempoolFees:
-		return mempoolFees(charts, bin)
+		return mempoolFees(charts, axis, bin)
 	}
 	return nil, UnknownChartErr
 }
 
-func mempoolSize(charts *ChartData, bin binLevel) ([]byte, error) {
+func mempoolSize(charts *ChartData, axis axisType, bin binLevel) ([]byte, error) {
 	var dates, sizes ChartUints
 
-	var key = fmt.Sprintf("%s-%s", Mempool, TimeAxis)
+	key := fmt.Sprintf("%s-%s", Mempool, HeightAxis)
+	if axis == TimeAxis {
+		key = fmt.Sprintf("%s-%s", Mempool, TimeAxis)
+	}
 	if bin != defaultBin {
 		key = fmt.Sprintf("%s-%s", key, bin)
 	}
@@ -1233,10 +1236,13 @@ func mempoolSize(charts *ChartData, bin binLevel) ([]byte, error) {
 	return charts.Encode(nil, dates, sizes)
 }
 
-func mempoolTxCount(charts *ChartData, bin binLevel) ([]byte, error) {
+func mempoolTxCount(charts *ChartData, axis axisType, bin binLevel) ([]byte, error) {
 	var dates, txCounts ChartUints
 
-	var key = fmt.Sprintf("%s-%s", Mempool, TimeAxis)
+	key := fmt.Sprintf("%s-%s", Mempool, HeightAxis)
+	if axis == TimeAxis {
+		key = fmt.Sprintf("%s-%s", Mempool, TimeAxis)
+	}
 	if bin != defaultBin {
 		key = fmt.Sprintf("%s-%s", key, bin)
 	}
@@ -1257,11 +1263,14 @@ func mempoolTxCount(charts *ChartData, bin binLevel) ([]byte, error) {
 	return charts.Encode(nil, dates, txCounts)
 }
 
-func mempoolFees(charts *ChartData, bin binLevel) ([]byte, error) {
+func mempoolFees(charts *ChartData, axis axisType, bin binLevel) ([]byte, error) {
 	var dates ChartUints
 	var fees ChartFloats
 
-	var key = fmt.Sprintf("%s-%s", Mempool, TimeAxis)
+	key := fmt.Sprintf("%s-%s", Mempool, HeightAxis)
+	if axis == TimeAxis {
+		key = fmt.Sprintf("%s-%s", Mempool, TimeAxis)
+	}
 	if bin != defaultBin {
 		key = fmt.Sprintf("%s-%s", key, bin)
 	}

--- a/postgres/network_snapshot.go
+++ b/postgres/network_snapshot.go
@@ -863,6 +863,7 @@ func (pg *PgDb) fetchNetworkSnapshotChart(ctx context.Context, charts *cache.Cha
 		set.versionDates = append(set.versionDates, uint64(d))
 	}
 
+	fmt.Println(done)
 	return set, func() {}, true, nil
 }
 

--- a/postgres/network_snapshot.go
+++ b/postgres/network_snapshot.go
@@ -863,7 +863,6 @@ func (pg *PgDb) fetchNetworkSnapshotChart(ctx context.Context, charts *cache.Cha
 		set.versionDates = append(set.versionDates, uint64(d))
 	}
 
-	fmt.Println(done)
 	return set, func() {}, true, nil
 }
 

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -600,6 +600,7 @@ func (s *Server) mempoolPage(res http.ResponseWriter, req *http.Request) {
 	}
 
 	data["mempool"] = mempoolData
+	data["blockTime"] = s.activeChain.TargetTimePerBlock.Seconds()
 
 	s.render("mempool.html", data, res)
 }
@@ -701,6 +702,7 @@ func (s *Server) propagation(res http.ResponseWriter, req *http.Request) {
 	}
 
 	data["propagation"] = block
+	data["blockTime"] = s.activeChain.TargetTimePerBlock.Seconds()
 
 	s.render("propagation.html", data, res)
 }

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -272,7 +272,7 @@ export default class extends Controller {
     this.lastZoom = Zoom.object(start, end)
     this.settings.zoom = Zoom.encode(this.lastZoom)
     let ex = this.chartsView.xAxisExtremes()
-    let option = Zoom.mapKey(this.settings.zoom, ex, 1)
+    let option = Zoom.mapKey(this.settings.zoom, ex, this.isHeightAxis() ? this.avgBlockTime : 1)
     setActiveOptionBtn(option, this.zoomOptionTargets)
   }
 

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -24,7 +24,7 @@ export default class extends Controller {
       'chartWrapper', 'viewOption', 'labels', 'viewOptionControl', 'messageView',
       'chartDataTypeSelector', 'chartDataType', 'chartOptions', 'labels', 'selectedMempoolOpt',
       'selectedNumberOfRows', 'numPageWrapper', 'loadingData',
-      'zoomSelector', 'zoomOption', 'interval', 'graphIntervalWrapper'
+      'zoomSelector', 'zoomOption', 'interval', 'graphIntervalWrapper', 'axisOption'
     ]
   }
 
@@ -124,7 +124,10 @@ export default class extends Controller {
       this.selectedNumberOfRowsberOfRows = this.selectedNumberOfRowsTarget.value
       url = `/getmempool?page=${this.nextPage}&records-per-page=${this.selectedNumberOfRowsberOfRows}&view-option=${this.selectedViewOption}`
     } else {
-      url = `/api/charts/mempool/${this.dataType}?bin=${this.selectedInterval()}`
+      url = `/api/charts/mempool/${this.dataType}?axis=${this.selectedAxis()}`
+    }
+    if (this.selectedAxis() === 'time') {
+      url += `&bin=${this.selectedInterval()}`
     }
 
     const _this = this
@@ -215,6 +218,29 @@ export default class extends Controller {
     this.fetchData(this.selectedViewOption)
   }
 
+  selectedAxis () {
+    let axis = selectedOption(this.axisOptionTargets)
+    if (!axis) {
+      axis = 'time'
+    }
+    return axis
+  }
+
+  isHeightAxis () {
+    return this.selectedAxis() === 'height'
+  }
+
+  setAxis (e) {
+    const option = e.currentTarget.dataset.option
+    if (option === 'time') {
+      show(this.graphIntervalWrapperTarget)
+    } else {
+      hide(this.graphIntervalWrapperTarget)
+    }
+    setActiveOptionBtn(option, this.axisOptionTargets)
+    this.fetchData(this.selectedViewOption)
+  }
+
   async validateZoom () {
     await animationFrame()
     await animationFrame()
@@ -276,32 +302,35 @@ export default class extends Controller {
           this.title = '# of Transactions'
           break
       }
-      let minDate, maxDate
+      let minVal, maxVal
 
-      data.x.forEach(unixTime => {
-        let date = new Date(unixTime * 1000)
-        if (minDate === undefined || date < minDate) {
-          minDate = date
+      data.x.forEach(record => {
+        let val = record
+        if (!this.isHeightAxis()) {
+          val = new Date(record * 1000)
+        }
+        if (minVal === undefined || val < minVal) {
+          minVal = val
         }
 
-        if (maxDate === undefined || date > maxDate) {
-          maxDate = date
+        if (maxVal === undefined || val > maxVal) {
+          maxVal = val
         }
       })
 
-      const chartData = zipXYZData(data)
-
+      const chartData = zipXYZData(data, this.isHeightAxis())
+      let xLabel = this.isHeightAxis() ? 'Height' : 'Time'
       _this.chartsView = new Dygraph(_this.chartsViewTarget, chartData,
         {
           legend: 'always',
           includeZero: true,
-          dateWindow: [minDate, maxDate],
+          dateWindow: [minVal, maxVal],
           legendFormatter: legendFormatter,
           digitsAfterDecimal: 8,
           labelsDiv: _this.labelsTarget,
           ylabel: _this.title,
-          xlabel: 'Date',
-          labels: ['Date', _this.title],
+          xlabel: xLabel,
+          labels: [xLabel, _this.title],
           labelsUTC: true,
           labelsKMB: true,
           maxNumberWidth: 10,
@@ -318,7 +347,7 @@ export default class extends Controller {
       )
 
       _this.validateZoom()
-      updateZoomSelector(_this.zoomOptionTargets, minDate, maxDate)
+      updateZoomSelector(_this.zoomOptionTargets, minVal, maxVal)
       show(this.zoomSelectorTarget)
     }
   }

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -45,6 +45,7 @@ export default class extends Controller {
     this.drawCallback = this._drawCallback.bind(this)
 
     this.dataType = this.chartDataTypeTarget.getAttribute('data-initial-value')
+    this.avgBlockTime = parseInt(this.data.get('blockTime')) * 1000
 
     this.selectedViewOption = this.viewOptionControlTarget.getAttribute('data-initial-value')
     if (this.selectedViewOption === 'chart') {
@@ -248,7 +249,7 @@ export default class extends Controller {
     this.limits = this.chartsView.xAxisExtremes()
     var selected = this.selectedZoom()
     if (selected) {
-      this.lastZoom = Zoom.validate(selected, this.limits, 1, 1)
+      this.lastZoom = Zoom.validate(selected, this.limits, 1, this.isHeightAxis() ? this.avgBlockTime : 1)
     } else {
       this.lastZoom = Zoom.project(this.settings.zoom, oldLimits, this.limits)
     }
@@ -347,7 +348,7 @@ export default class extends Controller {
       )
 
       _this.validateZoom()
-      updateZoomSelector(_this.zoomOptionTargets, minVal, maxVal)
+      updateZoomSelector(_this.zoomOptionTargets, minVal, maxVal, this.isHeightAxis() ? this.avgBlockTime : 1)
       show(this.zoomSelectorTarget)
     }
   }

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -125,10 +125,7 @@ export default class extends Controller {
       this.selectedNumberOfRowsberOfRows = this.selectedNumberOfRowsTarget.value
       url = `/getmempool?page=${this.nextPage}&records-per-page=${this.selectedNumberOfRowsberOfRows}&view-option=${this.selectedViewOption}`
     } else {
-      url = `/api/charts/mempool/${this.dataType}?axis=${this.selectedAxis()}`
-    }
-    if (this.selectedAxis() === 'time') {
-      url += `&bin=${this.selectedInterval()}`
+      url = `/api/charts/mempool/${this.dataType}?axis=${this.selectedAxis()}&bin=${this.selectedInterval()}`
     }
 
     const _this = this
@@ -233,11 +230,6 @@ export default class extends Controller {
 
   setAxis (e) {
     const option = e.currentTarget.dataset.option
-    if (option === 'time') {
-      show(this.graphIntervalWrapperTarget)
-    } else {
-      hide(this.graphIntervalWrapperTarget)
-    }
     setActiveOptionBtn(option, this.axisOptionTargets)
     this.fetchData(this.selectedViewOption)
   }

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -439,10 +439,7 @@ export default class extends Controller {
     showLoading(this.loadingDataTarget, elementsToToggle)
 
     const _this = this
-    let url = `/api/charts/propagation/${this.chartType}?extras=${this.syncSources.join('|')}&axis=${this.selectedAxis()}`
-    if (this.selectedAxis() === 'time') {
-      url += `&bin=${this.selectedInterval()}`
-    }
+    const url = `/api/charts/propagation/${this.chartType}?extras=${this.syncSources.join('|')}&axis=${this.selectedAxis()}&bin=${this.selectedInterval()}`
     axios.get(url).then(function (response) {
       hideLoading(_this.loadingDataTarget, elementsToToggle)
       if (!response.data.x || response.data.x.length === 0) {

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -617,7 +617,7 @@ export default class extends Controller {
     this.lastZoom = Zoom.object(start, end)
     this.settings.zoom = Zoom.encode(this.lastZoom)
     let ex = this.chartsView.xAxisExtremes()
-    let option = Zoom.mapKey(this.settings.zoom, ex, 1)
+    let option = Zoom.mapKey(this.settings.zoom, ex, this.isHeightAxis() ? this.avgBlockTime : 1)
     setActiveOptionBtn(option, this.zoomOptionTargets)
   }
 

--- a/web/public/app/src/controllers/propagation_controller.js
+++ b/web/public/app/src/controllers/propagation_controller.js
@@ -415,10 +415,7 @@ export default class extends Controller {
     showLoading(this.loadingDataTarget, elementsToToggle)
 
     const _this = this
-    let url = `/api/charts/propagation/${this.chartType}?axis=${this.selectedAxis()}`
-    if (this.selectedAxis() === 'time') {
-      url += `&bin=${this.selectedInterval()}`
-    }
+    let url = `/api/charts/propagation/${this.chartType}?axis=${this.selectedAxis()}&bin=${this.selectedInterval()}`
     axios.get(url).then(function (response) {
       hideLoading(_this.loadingDataTarget, elementsToToggle)
       _this.plotGraph(response.data)
@@ -668,11 +665,6 @@ export default class extends Controller {
 
   setAxis (e) {
     const option = e.currentTarget.dataset.option
-    if (option === 'time') {
-      show(this.graphIntervalWrapperTarget)
-    } else {
-      hide(this.graphIntervalWrapperTarget)
-    }
     setActiveOptionBtn(option, this.axisOptionTargets)
     this.plotSelectedChart()
   }

--- a/web/public/app/src/utils.js
+++ b/web/public/app/src/utils.js
@@ -308,8 +308,9 @@ export function csv (dataSet, labelsCount) {
   return csv
 }
 
-export function updateZoomSelector (targets, minDate, maxDate) {
-  const duration = maxDate - minDate
+export function updateZoomSelector (targets, minVal, maxVal, scale) {
+  scale = scale || 1
+  const duration = scale * (maxVal - minVal)
   const days = duration / (1000 * 60 * 60 * 24)
   targets.forEach(el => {
     let showElement = false

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -3,7 +3,7 @@
 {{ template "html-head" }}
 
 <body data-controller="receive">
-<div class="body" data-controller="mempool">
+<div class="body" data-controller="mempool" data-mempool-block-time="{{.blockTime}}">
     {{ template "header" }}
     <div class="content">
         <div class="container-fluid">

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -205,8 +205,31 @@
             <div data-target="mempool.chartWrapper" class="inner-content chart-wrapper pl-2 pr-2 mb-5">
                 <div id="chart" data-target="mempool.chartsView"
                         style="width:100%; height:73vh; margin:0 auto;"></div>
-                <div class="d-flex justify-content-center legend-wrapper">
+                <div class="d-flex justify-content-center legend-wrapper d-none">
                     <div class="legend d-flex" data-target="mempool.labels"></div>
+                </div>
+
+                <div class="d-flex flex-wrap justify-content-center align-items-center mb-1 mt-1">
+                    <div class="chart-control chart-control-wrapper">
+                        <ul class="nav nav-pills">
+                            <li class="nav-item active">
+                                <a class="nav-link active"
+                                    href="javascript:void(0);"
+                                    data-target="mempool.axisOption"
+                                    data-action="click->mempool#setAxis"
+                                    data-option="time"
+                                >Time</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link"
+                                    href="javascript:void(0);"
+                                    data-target="mempool.axisOption"
+                                    data-action="click->mempool#setAxis"
+                                    data-option="height"
+                                >Blocks</a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
             <div data-target="mempool.messageView" class="d-hide mx-auto">

--- a/web/views/propagation.html
+++ b/web/views/propagation.html
@@ -3,7 +3,7 @@
 {{ template "html-head" }}
 
 <body data-controller="receive">
-<div class="body" data-controller="propagation">
+<div class="body" data-controller="propagation" data-propagation-block-time="{{.blockTime}}">
     {{ template "header" }}
     <div class="content">
         <div class="container-fluid">


### PR DESCRIPTION
Close #156 
This PR added the ability to toggle between time and height on the x axis of the mempool chart page.
The mempool height is gotten from the corresponding propagation data during chart cache update.
Grouping by day and hour is also added for height axis on the mempool and propagation chart page.
Also fixed the zoom feature for the height axis on the mempool and propagation page.