### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ profile*.png
 .DS_Store
 
 charts-cache.glob
+node_modules

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -177,6 +177,7 @@ type ConfigFileOptions struct {
 // CommandLineOptions holds the top-level options/flags that are displayed on the command-line menu
 type CommandLineOptions struct {
 	Reset      bool   `short:"R" long:"reset" description:"Drop all database tables and start over"`
+	ResetCache bool   `short:"E" long:"reset-cache" description:"Drop all database tables used in storing computed cache data"`
 	ConfigFile string `short:"C" long:"configfile" description:"Path to Configuration file"`
 	HttpMode   string `long:"http" description:"Launch http server"`
 }

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -294,6 +295,10 @@ func LoadConfig() (*Config, []string, error) {
 	if net.ParseIP(cfg.Seeder) == nil {
 		str := "\"%s\" is not a valid textual representation of an IP address"
 		return nil, nil, fmt.Errorf(str, cfg.Seeder)
+	}
+
+	if len(cfg.SyncDatabases) != len(cfg.SyncSources) {
+		return nil, nil, errors.New("You must set the same number of sync source and database.")
 	}
 
 	return &cfg, unknownArg, nil

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1005,8 +1005,10 @@ func (charts *Manager) encodeArr(keys []string, sets []Lengther) ([]byte, error)
 	return json.Marshal(response)
 }
 
-// trim remove points that has 0s in all yAxis.
-func (charts *Manager) trim(sets ...Lengther) []Lengther {
+// Trim remove points that has 0s in all yAxis.
+func (charts *Manager) Trim(sets ...Lengther) []Lengther {
+	setsCopy := make([]Lengther, len(sets))
+	copy(setsCopy, sets)
 	dLen := sets[0].Length()
 	for i := dLen - 1; i >= 0; i-- {
 		var isZero bool = true
@@ -1026,6 +1028,9 @@ func (charts *Manager) trim(sets ...Lengther) []Lengther {
 		}
 	}
 
+	if sets[0].Length() == 0 {
+		return setsCopy
+	}
 	return sets
 }
 
@@ -1037,7 +1042,7 @@ func MakePowChart(charts *Manager, dates ChartUints, deviations []ChartNullUints
 	}
 	var recCopy = make([]Lengther, len(recs))
 	copy(recCopy, recs)
-	recs = charts.trim(recs...)
+	recs = charts.Trim(recs...)
 	if recs[0].Length() == 0 {
 		recs = recCopy
 	}
@@ -1052,7 +1057,7 @@ func MakeVspChart(charts *Manager, dates ChartUints, deviations []ChartNullData,
 
 	var recCopy = make([]Lengther, len(recs))
 	copy(recCopy, recs)
-	recs = charts.trim(recs...)
+	recs = charts.Trim(recs...)
 	if recs[0].Length() == 0 {
 		recs = recCopy
 	}

--- a/datasync/datasync.go
+++ b/datasync/datasync.go
@@ -43,6 +43,10 @@ func (s *SyncCoordinator) Syncer(tableName string) (Syncer, bool) {
 func (s *SyncCoordinator) StartSyncing(ctx context.Context) {
 	runSyncers := func() {
 		for _, source := range s.instances {
+			// empty url means the DBs is configured only for offline comparison without syncing
+			if source.url == "" {
+				continue
+			}
 			for i := 0; i <= len(s.syncersKeys); i++ {
 				tableName := s.syncersKeys[i]
 				syncer, found := s.syncers[tableName]

--- a/main.go
+++ b/main.go
@@ -149,6 +149,27 @@ func _main(ctx context.Context) error {
 		return nil
 	}
 
+	if cfg.ResetCache {
+		resetTables, err := helpers.RequestYesNoConfirmation("Are you sure you want to reset the dcrextdata cache data?", "")
+		if err != nil {
+			return fmt.Errorf("error reading your response: %s", err.Error())
+		}
+
+		if resetTables {
+			err = db.DropCacheTables()
+			if err != nil {
+				db.Close()
+				log.Error("Could not drop tables: ", err)
+				return err
+			}
+
+			fmt.Println("Done. You can restart the server now.")
+			return nil
+		}
+
+		return nil
+	}
+
 	// Display app version.
 	log.Infof("%s version %v (Go version %s)", app.AppName, app.Version(), runtime.Version())
 

--- a/postgres/setup.go
+++ b/postgres/setup.go
@@ -667,6 +667,40 @@ func (pg *PgDb) DropAllTables() error {
 	return nil
 }
 
+func (pg *PgDb) DropCacheTables() error {
+	// vsp_tick
+	if err := pg.dropTable("vsp_tick_bin"); err != nil {
+		return err
+	}
+
+	// pow_bin
+	if err := pg.dropTable("pow_bin"); err != nil {
+		return err
+	}
+
+	// mempool_bin
+	if err := pg.dropTable("mempool_bin"); err != nil {
+		return err
+	}
+
+	// propagation
+	if err := pg.dropTable("propagation"); err != nil {
+		return err
+	}
+
+	// vote_receive_time_deviation
+	if err := pg.dropTable("vote_receive_time_deviation"); err != nil {
+		return err
+	}
+
+	//network_snapshot_bin
+	if err := pg.dropTable("network_snapshot_bin"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (pg *PgDb) dropTable(name string) error {
 	log.Tracef("Dropping table %s", name)
 	_, err := pg.db.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, name))

--- a/postgres/vsp.go
+++ b/postgres/vsp.go
@@ -977,7 +977,7 @@ func (pg *PgDb) UpdateVspHourlyChart(ctx context.Context) error {
 func (pg *PgDb) UpdateVspDailyChart(ctx context.Context) error {
 	log.Info("Updating VSP daily average")
 	lastDayEntry, err := models.VSPTickBins(
-		models.VSPTickBinWhere.Bin.EQ(string(cache.HourBin)),
+		models.VSPTickBinWhere.Bin.EQ(string(cache.DayBin)),
 		qm.OrderBy(fmt.Sprintf("%s desc", models.VSPTickBinColumns.Time)),
 	).One(ctx, pg.db)
 	if err != nil && err != sql.ErrNoRows {
@@ -1011,7 +1011,7 @@ func (pg *PgDb) UpdateVspDailyChart(ctx context.Context) error {
 
 		records, err := models.VSPTickBins(
 			models.VSPTickBinWhere.VSPID.EQ(source.ID),
-			models.VSPTickBinWhere.Bin.EQ(string(cache.DayBin)),
+			models.VSPTickBinWhere.Bin.EQ(string(cache.HourBin)),
 			models.VSPTickBinWhere.Time.GTE(nextDay.Unix()),
 		).All(ctx, tx)
 		if err != nil {

--- a/web/public/app/src/controllers/mempool_controller.js
+++ b/web/public/app/src/controllers/mempool_controller.js
@@ -24,7 +24,7 @@ export default class extends Controller {
       'chartWrapper', 'viewOption', 'labels', 'viewOptionControl', 'messageView',
       'chartDataTypeSelector', 'chartDataType', 'chartOptions', 'labels', 'selectedMempoolOpt',
       'selectedNumberOfRows', 'numPageWrapper', 'loadingData',
-      'zoomSelector', 'zoomOption', 'interval', 'graphIntervalWrapper', 'axisOption'
+      'zoomSelector', 'zoomOption', 'interval', 'graphIntervalWrapper'
     ]
   }
 
@@ -133,7 +133,7 @@ export default class extends Controller {
       this.selectedNumberOfRowsberOfRows = this.selectedNumberOfRowsTarget.value
       url = `/getmempool?page=${this.nextPage}&records-per-page=${this.selectedNumberOfRowsberOfRows}&view-option=${this.selectedViewOption}`
     } else {
-      url = `/api/charts/mempool/${this.dataType}?axis=${this.selectedAxis()}&bin=${this.selectedInterval()}`
+      url = `/api/charts/mempool/${this.dataType}?axis=time&bin=${this.selectedInterval()}`
     }
 
     const _this = this
@@ -226,24 +226,6 @@ export default class extends Controller {
     insertOrUpdateQueryParam('bin', option, 'day')
   }
 
-  selectedAxis () {
-    let axis = selectedOption(this.axisOptionTargets)
-    if (!axis) {
-      axis = 'time'
-    }
-    return axis
-  }
-
-  isHeightAxis () {
-    return this.selectedAxis() === 'height'
-  }
-
-  setAxis (e) {
-    const option = e.currentTarget.dataset.option
-    setActiveOptionBtn(option, this.axisOptionTargets)
-    this.fetchData(this.selectedViewOption)
-  }
-
   async validateZoom () {
     await animationFrame()
     await animationFrame()
@@ -251,7 +233,7 @@ export default class extends Controller {
     this.limits = this.chartsView.xAxisExtremes()
     var selected = this.selectedZoom()
     if (selected) {
-      this.lastZoom = Zoom.validate(selected, this.limits, 1, this.isHeightAxis() ? this.avgBlockTime : 1)
+      this.lastZoom = Zoom.validate(selected, this.limits, 1, 1)
     } else {
       this.lastZoom = Zoom.project(this.settings.zoom, oldLimits, this.limits)
     }
@@ -274,7 +256,7 @@ export default class extends Controller {
     this.lastZoom = Zoom.object(start, end)
     this.settings.zoom = Zoom.encode(this.lastZoom)
     let ex = this.chartsView.xAxisExtremes()
-    let option = Zoom.mapKey(this.settings.zoom, ex, this.isHeightAxis() ? this.avgBlockTime : 1)
+    let option = Zoom.mapKey(this.settings.zoom, ex, 1)
     setActiveOptionBtn(option, this.zoomOptionTargets)
   }
 
@@ -308,10 +290,7 @@ export default class extends Controller {
       let minVal, maxVal
 
       data.x.forEach(record => {
-        let val = record
-        if (!this.isHeightAxis()) {
-          val = new Date(record * 1000)
-        }
+        let val = new Date(record * 1000)
         if (minVal === undefined || val < minVal) {
           minVal = val
         }
@@ -321,8 +300,8 @@ export default class extends Controller {
         }
       })
 
-      const chartData = zipXYZData(data, this.isHeightAxis())
-      let xLabel = this.isHeightAxis() ? 'Height' : 'Time'
+      const chartData = zipXYZData(data)
+      let xLabel = 'Time'
       _this.chartsView = new Dygraph(_this.chartsViewTarget, chartData,
         {
           legend: 'always',
@@ -350,7 +329,7 @@ export default class extends Controller {
       )
 
       _this.validateZoom()
-      if (updateZoomSelector(_this.zoomOptionTargets, minVal, maxVal, this.isHeightAxis() ? this.avgBlockTime : 1)) {
+      if (updateZoomSelector(_this.zoomOptionTargets, minVal, maxVal, 1)) {
         show(this.zoomSelectorTarget)
       } else {
         hide(this.zoomSelectorTarget)

--- a/web/views/mempool.html
+++ b/web/views/mempool.html
@@ -208,29 +208,6 @@
                 <div class="d-flex justify-content-center legend-wrapper d-none">
                     <div class="legend d-flex" data-target="mempool.labels"></div>
                 </div>
-
-                <div class="d-flex flex-wrap justify-content-center align-items-center mb-1 mt-1">
-                    <div class="chart-control chart-control-wrapper">
-                        <ul class="nav nav-pills">
-                            <li class="nav-item active">
-                                <a class="nav-link active"
-                                    href="javascript:void(0);"
-                                    data-target="mempool.axisOption"
-                                    data-action="click->mempool#setAxis"
-                                    data-option="time"
-                                >Time</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link"
-                                    href="javascript:void(0);"
-                                    data-target="mempool.axisOption"
-                                    data-action="click->mempool#setAxis"
-                                    data-option="height"
-                                >Blocks</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
             </div>
             <div data-target="mempool.messageView" class="d-hide mx-auto">
             </div>


### PR DESCRIPTION
The following were resolved in this PR
- Fixed VSP daily chart
- Wrong block height on the mempool and propagation page
- Added an option for resetting the cached data of dcrextdata.
- Added the ability to configure an already populated db for comparison on the propagation page without the need for syncing
