### PR TITLE
Exchange and Community stat Chart view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ profile*.png
 .DS_Store
 
 charts-cache.glob
+node_modules

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1005,8 +1005,8 @@ func (charts *Manager) encodeArr(keys []string, sets []Lengther) ([]byte, error)
 	return json.Marshal(response)
 }
 
-// trim remove points that has 0s in all yAxis.
-func (charts *Manager) trim(sets ...Lengther) []Lengther {
+// Trim remove points that has 0s in all yAxis.
+func (charts *Manager) Trim(sets ...Lengther) []Lengther {
 	dLen := sets[0].Length()
 	for i := dLen - 1; i >= 0; i-- {
 		var isZero bool = true
@@ -1037,7 +1037,7 @@ func MakePowChart(charts *Manager, dates ChartUints, deviations []ChartNullUints
 	}
 	var recCopy = make([]Lengther, len(recs))
 	copy(recCopy, recs)
-	recs = charts.trim(recs...)
+	recs = charts.Trim(recs...)
 	if recs[0].Length() == 0 {
 		recs = recCopy
 	}
@@ -1052,7 +1052,7 @@ func MakeVspChart(charts *Manager, dates ChartUints, deviations []ChartNullData,
 
 	var recCopy = make([]Lengther, len(recs))
 	copy(recCopy, recs)
-	recs = charts.trim(recs...)
+	recs = charts.Trim(recs...)
 	if recs[0].Length() == 0 {
 		recs = recCopy
 	}

--- a/postgres/commStat.go
+++ b/postgres/commStat.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/planetdecred/dcrextdata/commstats"
 	"github.com/planetdecred/dcrextdata/postgres/models"
 	"github.com/volatiletech/sqlboiler/boil"
@@ -210,6 +211,7 @@ func (pg *PgDb) CommunityChart(ctx context.Context, platform string, dataType st
 	}
 	sqlTemplate += " ORDER BY date"
 	query := fmt.Sprintf(sqlTemplate, templateArgs...)
+	spew.Dump(query)
 
 	rows, err := pg.db.QueryContext(ctx, query)
 	if err != nil {

--- a/web/public/app/src/controllers/exchange_controller.js
+++ b/web/public/app/src/controllers/exchange_controller.js
@@ -15,6 +15,7 @@ import { animationFrame } from '../helpers/animation_helper'
 import TurboQuery from '../helpers/turbolinks_helper'
 
 const Dygraph = require('../../../dist/js/dygraphs.min.js')
+var chartData
 
 export default class extends Controller {
   static get targets () {
@@ -24,7 +25,7 @@ export default class extends Controller {
       'exRowTemplate', 'currentPage', 'selectedNum', 'exchangeTableWrapper', 'tickWapper', 'viewOptionControl',
       'chartWrapper', 'labels', 'chartsView', 'selectedViewOption', 'hideOption', 'sourceWrapper', 'chartSelector',
       'pageSizeWrapper', 'chartSource', 'messageView', 'hideIntervalOption', 'viewOption',
-      'zoomSelector', 'zoomOption'
+      'zoomSelector', 'zoomOption', 'drawGridWrapper', 'drawGrid'
     ]
   }
 
@@ -67,6 +68,7 @@ export default class extends Controller {
     this.selectedViewOption = 'table'
     hide(this.messageViewTarget)
     hide(this.tickWapperTarget)
+    hide(this.drawGridWrapperTarget)
     show(this.hideOptionTarget)
     show(this.pageSizeWrapperTarget)
     hide(this.chartWrapperTarget)
@@ -94,6 +96,7 @@ export default class extends Controller {
     hide(this.pageSizeWrapperTarget)
     show(this.tickWapperTarget)
     show(this.zoomSelectorTarget)
+    show(this.drawGridWrapperTarget)
     hide(this.hideOptionTarget)
     hide(this.messageViewTarget)
     hide(this.numPageWrapperTarget)
@@ -313,6 +316,7 @@ export default class extends Controller {
             _this.drawInitialGraph()
           } else {
             hideLoading(_this.loadingDataTarget, [_this.chartWrapperTarget])
+            chartData = result
             _this.plotGraph(result)
           }
         }
@@ -366,6 +370,10 @@ export default class extends Controller {
     this.validateZoom()
   }
 
+  drawGridCheckChanged () {
+    this.plotGraph()
+  }
+
   async validateZoom () {
     await animationFrame()
     await animationFrame()
@@ -411,10 +419,10 @@ export default class extends Controller {
   }
 
   // exchange chart
-  plotGraph (data) {
+  plotGraph () {
     const _this = this
     let minDate, maxDate
-    data.x.forEach(unixTime => {
+    chartData.x.forEach(unixTime => {
       let date = new Date(unixTime * 1000)
       if (minDate === undefined || date < minDate) {
         minDate = date
@@ -435,14 +443,15 @@ export default class extends Controller {
       xlabel: 'Date',
       labels: _this.labels,
       colors: colors,
-      digitsAfterDecimal: 8
+      digitsAfterDecimal: 8,
+      drawGrid: this.drawGridTarget.checked
     }
 
-    const chartData = zipXYZData(data)
+    const data = zipXYZData(chartData)
 
     _this.chartsView = new Dygraph(
       _this.chartsViewTarget,
-      chartData, { ...options, ...extra }
+      data, { ...options, ...extra }
     )
 
     _this.validateZoom()

--- a/web/views/community.html
+++ b/web/views/community.html
@@ -97,10 +97,8 @@
 
                         <div class="chart-control-wrapper ml-1 d-none" data-target="commstat.dataTypeWrapper">
                             <div class="chart-control-label">Data Type</div>
-                            <div class="chart-control control-div p-0">
-                                <select data-target="commstat.dataType" data-initial-value="{{.dataType}}"
-                                        data-action="change->commstat#dataTypeChanged" class="form-control mr-5">
-                                </select>
+                            <div class="chart-control control-div p-0" data-target="commstat.dataTypeContainer">
+                                
                             </div>
                         </div>
 

--- a/web/views/community.html
+++ b/web/views/community.html
@@ -182,7 +182,7 @@
                                 </div>
 
                                 <div data-target="commstat.paginationWrapper"
-                                    class="page-size d-flex {{ if eq .viewOption "chart" }}d-none{{ end }}">
+                                    class="page-size d-flex mt-1 ml-5 {{ if eq .viewOption "chart" }}d-none{{ end }}">
                                     <a href="javascript:void(0)" data-target="commstat.previousPageButton"
                                     data-action="click->commstat#loadPreviousPage"
                                     class="mr-2 {{ if lt .previousPage 1 }}d-none{{ end }}">&lt;Previous </a>

--- a/web/views/exchange.html
+++ b/web/views/exchange.html
@@ -52,9 +52,6 @@
                                     <option value="{{$cpair.CurrencyPair}}" {{ if eq $cpair.CurrencyPair $selectedCurrencyPair}} selected {{ end }}>{{commonPair $cpair.CurrencyPair}}</option>
                                     {{ end }}
                                 </select>
-
-                            
-
                         </div>
                         <div data-target="exchange.intervalWapper" class="control-div p-0">
                             <div class="control-label">Interval:</div>
@@ -80,9 +77,9 @@
                         </select>
                     </div>
 
-                            <div class="chart-control-wrapper mr-2 mb-1" data-target="exchange.zoomSelector">
-                                <div class="chart-control">
-                                    <ul
+                    <div class="chart-control-wrapper mr-2" data-target="exchange.zoomSelector">
+                        <div class="chart-control">
+                            <ul
                                             class="nav nav-pills"
                                     >
                                         <li class="nav-item">
@@ -130,10 +127,17 @@
                                                     data-option="day"
                                             >Day</a>
                                         </li>
-                                    </ul>
-                                </div>
-                            </div>
+                            </ul>
+                        </div>
+                    </div>
 
+                    <div class="chart-control-wrapper" data-target="exchange.drawGridWrapper">
+                        <div class="chart-control form-check form-check-inline">
+                            <input data-target="exchange.drawGrid" data-action="click->exchange#drawGridCheckChanged"
+                            class="form-check-input ml-1" type="checkbox" checked>
+                            <label class="form-check-label">Show Draw Grid</label>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="inner-content {{ if .chartView }}d-none{{ end }}" data-target="exchange.exchangeTableWrapper">


### PR DESCRIPTION
Close #230 
Close #228 

- Added an option for toggling the grid line on the exchange chart.
- Added the ability to draw multiple chart on the community stat page with checkboxes to show/hide lines
- Resolved the overlapping of pagination and pagesize selector